### PR TITLE
Dev

### DIFF
--- a/computeImageDiff.py
+++ b/computeImageDiff.py
@@ -12,7 +12,7 @@ if image1.shape != image2.shape:
     raise ValueError("The two images must have the same size and number of channels.")
 
 # Compute the absolute difference between the two images
-diff_image = cv2.absdiff(image1, image2)
+diff_image = cv2.absdiff(image1, image2) * 100
 
 # Save the resulting image
 outputFilePath = "../../comparisonScrollData/comp" + fileName

--- a/computeImageDiff.py
+++ b/computeImageDiff.py
@@ -2,11 +2,11 @@ import cv2
 import os
 
 fileName = "06052.tif"
-file_path = "../fullScrollDataTest/" + fileName
+file_path = "../../fullScrollDataTest/" + fileName
 
 # Load the images
 image1 = cv2.imread(file_path)
-image2 = cv2.imread("../losslesslyCompressedScrollData/c" + fileName)
+image2 = cv2.imread("../../losslesslyCompressedScrollData/c" + fileName)
 # Ensure the images have the same size and number of channels
 if image1.shape != image2.shape:
     raise ValueError("The two images must have the same size and number of channels.")
@@ -15,7 +15,7 @@ if image1.shape != image2.shape:
 diff_image = cv2.absdiff(image1, image2)
 
 # Save the resulting image
-outputFilePath = "../comparisonScrollData/comp" + fileName
+outputFilePath = "../../comparisonScrollData/comp" + fileName
 cv2.imwrite(
     outputFilePath,
     cv2.cvtColor(diff_image, cv2.COLOR_RGB2BGR),

--- a/computeImageDiff.py
+++ b/computeImageDiff.py
@@ -1,0 +1,22 @@
+import cv2
+import os
+
+fileName = "06052.tif"
+file_path = "../fullScrollDataTest/" + fileName
+
+# Load the images
+image1 = cv2.imread(file_path)
+image2 = cv2.imread("../losslesslyCompressedScrollData/c" + fileName)
+# Ensure the images have the same size and number of channels
+if image1.shape != image2.shape:
+    raise ValueError("The two images must have the same size and number of channels.")
+
+# Compute the absolute difference between the two images
+diff_image = cv2.absdiff(image1, image2)
+
+# Save the resulting image
+outputFilePath = "../comparisonScrollData/comp" + fileName
+cv2.imwrite(
+    outputFilePath,
+    cv2.cvtColor(diff_image, cv2.COLOR_RGB2BGR),
+)

--- a/computeImageDiffColor.py
+++ b/computeImageDiffColor.py
@@ -1,0 +1,35 @@
+import cv2
+import os
+import numpy as np
+
+fileName = "06052.tif"
+file_path = "../../fullScrollDataTest/" + fileName
+
+# Load the images
+image1 = cv2.imread(file_path)
+image2 = cv2.imread("../../losslesslyCompressedScrollData/c" + fileName)
+# Ensure the images have the same size and number of channels
+if image1.shape != image2.shape:
+    raise ValueError("The two images must have the same size and number of channels.")
+
+# Compute the absolute difference between the two images
+diff_image = cv2.absdiff(image1, image2)
+
+# Set a threshold value for determining if pixels are different
+threshold_value = 1
+
+# Create a binary mask where pixel differences are greater than the threshold value
+mask = np.where(np.all(diff_image > threshold_value, axis=-1), 1, 0)
+
+# Create an array with the bright color (e.g., red) to apply to the different pixels
+bright_color = np.array([255, 0, 0], dtype=np.uint8)
+
+# Apply the bright color to the different pixels using the mask
+colored_diff = np.where(mask[..., np.newaxis] == 1, bright_color, diff_image)
+
+# Save the resulting image
+outputFilePath = "../../comparisonScrollData/comp" + fileName
+cv2.imwrite(
+    outputFilePath,
+    cv2.cvtColor(colored_diff, cv2.COLOR_RGB2BGR),
+)

--- a/computeImageDiffColorRadius.py
+++ b/computeImageDiffColorRadius.py
@@ -1,0 +1,43 @@
+import cv2
+import os
+import numpy as np
+
+fileName = "06052.tif"  # file to compare before and after lossless compression
+file_path = "../../fullScrollData/" + fileName
+
+# Load the images
+image1 = cv2.imread(file_path)
+image2 = cv2.imread("../../losslesslyCompressedScrollData/c" + fileName)
+# Ensure the images have the same size and number of channels
+if image1.shape != image2.shape:
+    raise ValueError("The two images must have the same size and number of channels.")
+
+# Compute the absolute difference between the two images
+diff_image = cv2.absdiff(image1, image2)
+
+# Set a threshold value for determining if pixels are different
+threshold_value = 1
+
+# Create a binary mask where pixel differences are greater than the threshold value
+mask = np.where(np.all(diff_image > threshold_value, axis=-1), 1, 0)
+
+# Create an array with the bright color (e.g., red) to apply to the different pixels
+bright_color = np.array([205, 0, 0], dtype=np.uint8)
+
+radius = 5
+
+# Create a circular structuring element for dilation
+kernel = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (2 * radius + 1, 2 * radius + 1))
+
+# Dilate the binary mask to create a radius around the different pixels
+dilated_mask = cv2.dilate(mask.astype(np.uint8), kernel)
+
+# Apply the bright color to the dilated mask
+colored_diff = np.where(dilated_mask[..., np.newaxis] == 1, bright_color, diff_image)
+
+# Save the resulting image
+outputFilePath = "../../comparisonScrollData/comp" + fileName
+cv2.imwrite(
+    outputFilePath,
+    cv2.cvtColor(colored_diff, cv2.COLOR_RGB2BGR),
+)

--- a/scrollSegBinary.py
+++ b/scrollSegBinary.py
@@ -12,6 +12,10 @@ print("Torchvision version:", torchvision.__version__)
 print("CUDA is available:", torch.cuda.is_available())
 torch.cuda.empty_cache()
 
+"""
+Development Script, scrollSegRLESeqRange.py is the most up to date script
+"""
+
 # sam_checkpoint = "segment-anything\sam_vit_l_0b3195.pth"
 sam_checkpoint = "segment-anything\sam_vit_h_4b8939.pth"
 model_type = "vit_h"

--- a/scrollSegRLE.py
+++ b/scrollSegRLE.py
@@ -13,10 +13,10 @@ print("CUDA is available:", torch.cuda.is_available())
 torch.cuda.empty_cache()
 
 # sam_checkpoint = "segment-anything\sam_vit_l_0b3195.pth"
-sam_checkpoint = "segment-anything\sam_vit_h_4b8939.pth"
+sam_checkpoint = "sam_vit_h_4b8939.pth"
 model_type = "vit_h"
 device = "cuda"
-filePath = "../fullScrollDataTest/06052.tif"
+filePath = "../../fullScrollDataTest/06052.tif"
 
 
 # coco_rle visualization
@@ -53,6 +53,13 @@ def visualize_rle_masks(image, rle_masks, alpha=0.5):
         ).astype(np.uint8)
 
     return masked_image
+
+
+def show_image(image):
+    plt.figure(figsize=(20, 20))
+    plt.imshow(image)
+    plt.axis("off")
+    plt.show()
 
 
 def scale_rle_mask(rle_mask, scale_factor):
@@ -102,17 +109,9 @@ print(len(masks))
 print(masks[0].keys())
 # print(masks)
 
-rle_image = visualize_rle_mask(downsampled_image, masks[0]["segmentation"])
-
-plt.figure(figsize=(20, 20))
-plt.imshow(rle_image)
-plt.axis("off")
-plt.show()
+# rle_image = visualize_rle_mask(downsampled_image, masks[0]["segmentation"])
+# show_image(rle_image)
 
 scaled_rle_mask = scale_rle_mask(masks[0]["segmentation"], 1 / scale_factor)
 rle_image = visualize_rle_mask(image, scaled_rle_mask)
-
-plt.figure(figsize=(20, 20))
-plt.imshow(rle_image)
-plt.axis("off")
-plt.show()
+show_image(rle_image)

--- a/scrollSegRLE.py
+++ b/scrollSegRLE.py
@@ -12,6 +12,10 @@ print("Torchvision version:", torchvision.__version__)
 print("CUDA is available:", torch.cuda.is_available())
 torch.cuda.empty_cache()
 
+"""
+Development Script, scrollSegRLESeqRange.py is the most up to date script
+"""
+
 # sam_checkpoint = "segment-anything\sam_vit_l_0b3195.pth"
 sam_checkpoint = "sam_vit_h_4b8939.pth"
 model_type = "vit_h"

--- a/scrollSegRLE.py
+++ b/scrollSegRLE.py
@@ -1,4 +1,4 @@
-from time import sleep
+from PIL import Image
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
 from pycocotools import mask as coco_mask
 import numpy as np
@@ -16,7 +16,8 @@ torch.cuda.empty_cache()
 sam_checkpoint = "sam_vit_h_4b8939.pth"
 model_type = "vit_h"
 device = "cuda"
-filePath = "../../fullScrollDataTest/06052.tif"
+fileName = "06052.tif"
+filePath = "../../fullScrollDataTest/" + fileName
 
 
 # coco_rle visualization
@@ -141,11 +142,20 @@ print(masks[0].keys())
 scaled_rle_mask = scale_rle_mask(
     masks[0]["segmentation"], 1 / scale_factor, image.shape
 )
-rle_image = visualize_rle_mask(image, scaled_rle_mask)
-show_image(rle_image)
+# rle_image = visualize_rle_mask(image, scaled_rle_mask)
+# show_image(rle_image)
 
-applied_mask = apply_mask(image, scaled_rle_mask)
-show_image(applied_mask)
+# applied_mask = apply_mask(image, scaled_rle_mask)
+# show_image(applied_mask)
 
-dilated_applied_mask = apply_dilated_mask(image, scaled_rle_mask, 2)
+dilated_applied_mask = apply_dilated_mask(image, scaled_rle_mask, 0.5)
 show_image(dilated_applied_mask)
+
+# Save the masked image as a TIFF file
+outputFilePath = "../../losslesslyCompressedScrollData/c" + fileName
+cv2.imwrite(
+    outputFilePath,
+    cv2.cvtColor(dilated_applied_mask, cv2.COLOR_RGB2BGR),
+)
+
+# compress_tiff(dilated_applied_mask, outputFilePath)

--- a/scrollSegRLESeqRange.py
+++ b/scrollSegRLESeqRange.py
@@ -16,7 +16,7 @@ torch.cuda.empty_cache()
 sam_checkpoint = "sam_vit_h_4b8939.pth"
 model_type = "vit_h"
 device = "cuda"
-filePath = "../../fullScrollDataTest/"
+filePath = "../../fullScrollData/"
 
 
 # coco_rle visualization
@@ -125,11 +125,12 @@ mask_generator = SamAutomaticMaskGenerator(
 
 scale_factor = 0.1  # Reduce the dimensions of the original size so batch can fit in GPU memory (8GB)
 
-formatted_numbers = [
-    f"{n:05d}" for n in range(6053, 6056)
-]  # change the ranges to change which images are processed
+formatted_numbers = []
+formatted_numbers += [
+    f"{n:05d}" for n in range(0, 5)
+]  # change the range to change which images are processed
 # formatted_numbers += [
-#     f"{n:06d}" for n in range(10000, 15000)
+#     f"{n:06d}" for n in range(12500, 12505)
 # ]  # artifact of how the images are named when I downloaded them, adding a 0 in front of all the 5 digit numbers
 
 print(formatted_numbers)
@@ -151,14 +152,14 @@ for number in formatted_numbers:
     scaled_rle_mask = scale_rle_mask(
         masks[0]["segmentation"], 1 / scale_factor, image.shape
     )
-    rle_image = visualize_rle_mask(image, scaled_rle_mask)
-    show_image(rle_image)
+    # rle_image = visualize_rle_mask(image, scaled_rle_mask)
+    # show_image(rle_image)
 
     # applied_mask = apply_mask(image, scaled_rle_mask)
     # show_image(applied_mask)
 
     dilated_applied_mask = apply_dilated_mask(image, scaled_rle_mask, 0.5)
-    show_image(dilated_applied_mask)
+    # show_image(dilated_applied_mask)
 
     # Save the masked image as a TIFF file
     outputFilePath = "../../losslesslyCompressedScrollData/c" + number + ".tif"

--- a/tempCodeRunnerFile.py
+++ b/tempCodeRunnerFile.py
@@ -1,0 +1,2 @@
+
+rle_image = visualize_rle_mask(image, scaled_rle_mask)


### PR DESCRIPTION
Python code to run SAM model on Vesuvius .tif images, and mask out the superfluous data. This allows for a lossless compression of the .tif reducing individual file sizes from 120MB to ~ 40MB with no loss of important information. There are also scripts to highlight any differences between the original and processed images to verify the claim no important information is lost.